### PR TITLE
use bigbytes of char type instead of int

### DIFF
--- a/src/bytesrw.ml
+++ b/src/bytesrw.ml
@@ -150,7 +150,7 @@ module Bytes = struct
       in
       let first = if first < 0 then 0 else first in
       let length = last - first + 1 in
-      let init i = Char.unsafe_chr (Bigarray.Array1.get bigbytes (first + i)) in
+      let init i = Bigarray.Array1.get bigbytes (first + i) in
       let bytes = Bytes.init length init in
       if first <= last then { bytes; first = 0; length } else
       if allow_eod then eod else err_empty_range ~first ~last ~len:(max + 1)
@@ -173,8 +173,8 @@ module Bytes = struct
     let to_string s = Bytes.sub_string s.bytes s.first s.length
     let to_bigbytes s =
       (* This should use blits. *)
-      Bigarray.Array1.init Bigarray.Int8_unsigned Bigarray.c_layout
-        s.length (fun i -> Bytes.get_uint8 s.bytes (s.first + i))
+      Bigarray.Array1.init Bigarray.Char Bigarray.c_layout
+        s.length (fun i -> Bytes.get s.bytes (s.first + i))
 
     let add_to_buffer b s = Buffer.add_subbytes b s.bytes s.first s.length
     let output_to_out_channel oc s =

--- a/src/bytesrw.mli
+++ b/src/bytesrw.mli
@@ -182,13 +182,13 @@ module Bytes : sig
 
     val of_bigbytes :
       ?first:int -> ?last:int ->
-      (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+      (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
       t
     (** [of_bigbytes] is like {!of_bytes} but {b copies} data from a bigbytes
         value. *)
 
     val of_bigbytes_or_eod : ?first:int -> ?last:int ->
-      (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+      (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
       t
     (** [of_bytes_or_eod] is like {!of_bytes_or_eod} but {b copies} data from
         a bigbytes value. *)
@@ -203,7 +203,7 @@ module Bytes : sig
     (** [to_bytes t] copies the range of [s] to a new [bytes] value. *)
 
     val to_bigbytes : t ->
-      (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+      (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     (** [to_bigbytes t] copies the range of [s] to a new bigbytes value. *)
 
     val to_string : t -> string


### PR DESCRIPTION
To me it seems, a bigarray with a char type is more adequate when they are going to be converted to bytes.