### PR TITLE
Bytes.Slice.compare doesnt check the last byte of two slices of equal length

### DIFF
--- a/src/bytesrw.ml
+++ b/src/bytesrw.ml
@@ -76,7 +76,7 @@ module Bytes = struct
       let cmp = ref 0 in
       let b0 = s0.bytes and b1 = s1.bytes in
       (* XXX it would be nice to have something faster based on memcmp *)
-      while (!cmp = 0 && !i < max) do
+      while (!cmp = 0 && !i <= max) do
         let c0 = Bytes.get b0 (first0 + !i) in
         let c1 = Bytes.get b1 (first1 + !i) in
         cmp := Char.compare c0 c1; incr i;


### PR DESCRIPTION
Before:

```
# let a = Bytesrw.Bytes.Slice.make (Bytes.of_string "a") ~first:0 ~length:1;;
val a : Bytesrw.Bytes.Slice.t = <abstr>
# let b = Bytesrw.Bytes.Slice.make (Bytes.of_string "b") ~first:0 ~length:1;;
val b : Bytesrw.Bytes.Slice.t = <abstr>
# Bytesrw.Bytes.Slice.compare a b;;
- : int = 0
# Bytesrw.Bytes.Slice.to_string a;;
- : string = "a"
# Bytesrw.Bytes.Slice.to_string b;;
- : string = "b"
```