### PR TITLE
Fix Bytes.Writer.limit raising Invalid_argument instead of Stream.Error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+- Fix `Bytes.Writer.limit` raising `Invalid_argument` instead of
+  `Stream.Error` when the remaining budget lands on exactly 0 at a slice
+  boundary.
+
 v0.4.0 2026-08-22 Zagreb
 ------------------------
 

--- a/src/bytesrw.ml
+++ b/src/bytesrw.ml
@@ -708,7 +708,9 @@ module Bytes = struct
           left := !left - slen;
           if !left >= 0 then write w slice else
           begin
-            write w (Option.get (Slice.take (slen + !left) slice));
+            (match Slice.take (slen + !left) slice with
+            | Some s -> write w s
+            | None -> ());
             if eod then write_eod w;
             lw.write <- write_only_eod;
             action w n

--- a/test/test_bytesrw.ml
+++ b/test/test_bytesrw.ml
@@ -340,6 +340,13 @@ let test_writer_limit =
   Bytes.Writer.write_eod lw;
   Test.string (Buffer.contents b) "121212";
   Test.invalid_arg @@ (fun () -> Bytes.Writer.write_string w "1234");
+  let b = Buffer.create 255 in
+  let w = Bytes.Writer.of_buffer b in
+  let lw = Bytes.Writer.limit 2 ~eod:true w in
+  Bytes.Writer.write_string lw "12";
+  Test.string (Buffer.contents b) "12";
+  test_stream_error @@ (fun () -> Bytes.Writer.write_string lw "3");
+  Test.string (Buffer.contents b) "12";
   ()
 
 let main () = Test.main @@ fun () -> Test.autorun ()


### PR DESCRIPTION
`Bytes.Writer.limit` trims an over-budget write with
`Slice.take (slen + !left) slice`. When a prior write had already
exhausted the budget exactly (`!left = 0`), the next write's trim amount
reduced to `0`. `Slice.take` treats a non-positive count as "nothing to
take" and returns `None`, so the unguarded `Option.get` raised
`Invalid_argument` instead of running the writer's documented over-limit
`action` (`Stream.Error` by default).

Fix: handle the `None` case by writing nothing (zero bytes need not be
written) and falling through to `action` as documented.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>